### PR TITLE
Fix Bug in Enumerable props_for

### DIFF
--- a/lib/active_model_react_props.rb
+++ b/lib/active_model_react_props.rb
@@ -5,8 +5,8 @@ module ActiveModelReactProps
     end.attributes!
   end
 
-  def props_for_collection(object, **options)
-    object.map { |obj| props_for(obj, **options) }
+  def props_for_collection(objects, **options)
+    objects.map { |obj| props_for(obj, **options) }
   end
 
   def errors_for(model)


### PR DESCRIPTION
- This PR fixes two issues: 
    - changes `is_a?` to `respond_to?` so recursion can work on an `ActiveRecord::Relation`
    - fixes the mistaken occurrence of `render_json_partial` with the intended `props_for`