### PR TITLE
Amend copyright holder

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018 Kevin Finn
+Copyright 2018 Relevant Healthcare Technologies, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
This code was developed at Relevant, so RHT is the copyright holder.
Fixing because it may matter during the Foothold transition as lawyers
scrutinize our OSS usage and licenses.